### PR TITLE
Add Relation#select_rows to retrieve raw results

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -13,7 +13,7 @@ module ActiveRecord
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly, :extending,
              :having, :create_with, :distinct, :references, :none, :unscope, :merge, to: :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, to: :all
-    delegate :pluck, :pick, :ids, to: :all
+    delegate :pluck, :pick, :ids, :select_rows, to: :all
 
     # Executes a custom SQL query against your database and returns all the results. The results will
     # be returned as an array with columns requested encapsulated as attributes of the model you call

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -226,6 +226,23 @@ module ActiveRecord
       pluck primary_key
     end
 
+    # Retrieve the records for the relation in raw format, _not_ typecasted.
+    # #select_rows returns an Array of Hashes representing the result set.
+    #
+    # This method is short-hand for
+    # <tt>ActiveRecord::Base.connection.exec_query(relation.to_sql).to_ary</tt>.
+    #
+    #   User.where(id: 1).select_rows
+    #   # => [{ "id" => 1, "name" => "Marco"}]
+    #
+    #   User.select('shard, count(*) as count').group(:shard).select_rows
+    #   # => [{ "shard" => 0, "count" => 16 }, { "shard" => 1, "count" => 17 }]
+    def select_rows
+      relation = spawn
+      result = skip_query_cache_if_necessary { klass.connection.select_all(relation.arel, nil) }
+      result.to_ary
+    end
+
     private
 
       def has_include?(column_name)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -846,6 +846,11 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal cool_first.color, Minivan.pick(:color)
   end
 
+  def test_select_rows
+    account = accounts(:signals37)
+    assert_equal [ account.attributes ], Account.where(id: account.id).select_rows
+  end
+
   def test_grouped_calculation_with_polymorphic_relation
     part = ShipPart.create!(name: "has trinket")
     part.trinkets.create!


### PR DESCRIPTION
### Summary

> _Relevant discussion: https://groups.google.com/forum/#!topic/rubyonrails-core/515O4ILeGvo_

Add support to retrieve "raw" database result rows from a relation.
No type casting is performed.

The result will always be equivalent to:
```ruby
ActiveRecord::Base.connection.exec_query(relation.to_sql).to_ary == relation.select_rows
# => true
```

### Other Information

The method is implemented as a very stripped down version of pluck, skipping field selection and type casting, thus should perform similarly.

One thing to notice is that I had two options when implementing this method:
* Return an Array of Hashes: `[{ id: 1, name: 'test' }]`
* Return an Array of Arrays: `[[1, 'test']]`

The former is similar to what we call "select" when dealing with relations, while the latter is more akin to a "pluck".

IMHO, a structured Hash (the first option) makes the most sense, as the output is unprocessed and not easy to navigate without column names.

There's also an argument to be made to also add `pluck_rows` for completeness, which would return the second option: an Array of Arrays. I chose not to implement it now, for the reason mentioned in the paragraph prior.

This is my first PR around here, feedback would be very much welcome!